### PR TITLE
chore: Null safety support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 ## 0.0.6
 
 * Null-safety support.
+* Introducing iOS support for Bluetooth feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@
 
 * Adding Location and LocationAlways features;
 * Formatting code.
+
+## 0.0.6
+
+* Null-safety support.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - bluetooth_enable (0.0.1):
+  - bluetooth_enable_fork (0.1.4):
     - Flutter
   - Flutter (1.0.0)
   - location (0.0.1):
@@ -8,14 +8,14 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - bluetooth_enable (from `.symlinks/plugins/bluetooth_enable/ios`)
+  - bluetooth_enable_fork (from `.symlinks/plugins/bluetooth_enable_fork/ios`)
   - Flutter (from `Flutter`)
   - location (from `.symlinks/plugins/location/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
 
 EXTERNAL SOURCES:
-  bluetooth_enable:
-    :path: ".symlinks/plugins/bluetooth_enable/ios"
+  bluetooth_enable_fork:
+    :path: ".symlinks/plugins/bluetooth_enable_fork/ios"
   Flutter:
     :path: Flutter
   location:
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler/ios"
 
 SPEC CHECKSUMS:
-  bluetooth_enable: 131bf222123b9c5020469d04a13cc253bc89298c
+  bluetooth_enable_fork: 73b8ca6e67230a9baa04010cd5c1e824e00d2797
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: bluetooth_enable_fork
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.5"
+    version: "8.3.0"
   permission_handler_platform_interface:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   http_parser:
     dependency: transitive
     description:

--- a/lib/utils/classes.dart
+++ b/lib/utils/classes.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-
 enum Feature {
   Bluetooth,
   BluetoothConnect,
@@ -12,10 +10,10 @@ enum Feature {
 class Result {
   final bool allOk;
   final Map<Feature, bool> _results;
-  Result(this._results, {@required this.allOk});
+  Result(this._results, {required this.allOk});
 
   bool getStatus(Feature feature) {
-    return this._results.containsKey(feature) && this._results[feature];
+    return this._results.containsKey(feature) && this._results[feature]!;
   }
 
   String toString() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: bluetooth_enable_fork
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.5"
+    version: "8.3.0"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=2.0.3"
 
 dependencies:
-  bluetooth_enable_fork: ^0.1.3
+  bluetooth_enable_fork: ^0.1.4
   flutter:
     sdk: flutter
   location: ^4.3.0
-  permission_handler: ^8.2.5
+  permission_handler: ^8.3.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grant_and_activate
 description: Activate services and ask for associated permissions with a single method call.
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/Alystrasz/grant_and_activate
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.5
 homepage: https://github.com/Alystrasz/grant_and_activate
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.3"
 
 dependencies:


### PR DESCRIPTION
Using `bluetooth_enable_fork` package version `v0.1.4` for null-safety also provides iOS Bluetooth support.